### PR TITLE
tweetnacl-sys: Use cty crate instead of libc

### DIFF
--- a/tweetnacl-sys/Cargo.toml
+++ b/tweetnacl-sys/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "jmesmon/sodalite" }
 appveyor = { repository = "jmesmon/sodalite" }
 
 [dependencies]
-libc = "0.2"
+cty = "0.2.1"
 
 [build-dependencies]
 cc = "1.0"

--- a/tweetnacl-sys/src/lib.rs
+++ b/tweetnacl-sys/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
-extern crate libc;
 
-pub use libc::{c_int, c_longlong, c_ulonglong};
+pub use cty::{c_int, c_longlong, c_ulonglong};
 
 extern "C" {
     pub fn crypto_auth_hmacsha512256_tweet(


### PR DESCRIPTION
This allows building in embedded environments. Previously `cargo build
--target thumbv6m-none-eabi` would fail because it couldn't find `c_int`
etc.